### PR TITLE
Switch from bundle to bundler in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "http://rubygems.org"
 
 gem 'rake'
-gem 'bundle'
+gem 'bundler'
 gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,6 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    bundle (0.0.1)
-      bundler
     diff-lcs (1.1.3)
     rake (0.9.2.2)
     rspec (2.11.0)
@@ -18,6 +16,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundle
+  bundler
   rake
   rspec


### PR DESCRIPTION
Whilst working on [Libraries.io](https://libraries.io) I noticed that this project depends on the [`bundle`](https://github.com/will/bundle) gem rather than [`bundler`](https://github.com/bundler/bundler/), this pull request fixes the typo and updates the Gemfile.lock